### PR TITLE
Use requests_gpgauthlib >= 0.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ tests_require = [
 install_requires = [
     'click>=6.0',
     'requests',
-    'requests_gpgauthlib',
+    'requests_gpgauthlib>=0.1.0',
 ]
 
 

--- a/src/wrench/exceptions.py
+++ b/src/wrench/exceptions.py
@@ -1,10 +1,18 @@
 from requests import Response
 
 
-class InputValidationError(Exception):
+class WrenchError(Exception):
     ...
 
 
-class HttpRequestError(Exception):
+class InputValidationError(WrenchError):
+    ...
+
+
+class HttpRequestError(WrenchError):
     def __init__(self, response: Response) -> None:
         self.response = response
+
+
+class FingerprintMismatchError(WrenchError):
+    ...


### PR DESCRIPTION
The new requests_gpgauthlib API doesn't mandate the `server_fingerprint` anymore and makes `auth_api` optional