### PR TITLE
Fix command name in error message

### DIFF
--- a/src/wrench/commands.py
+++ b/src/wrench/commands.py
@@ -633,7 +633,7 @@ def main() -> None:
         cli(obj={})
     except GPGAuthNoSecretKeyError:
         click.secho(
-            "Error: no secret key available. Please export your key in Passbolt and run `wrench import_key "
+            "Error: no secret key available. Please export your key in Passbolt and run `wrench import-key "
             "<path_to_key>`.", err=True
         )
         sys.exit(ExitStatus.NO_SECRET_KEY.value)


### PR DESCRIPTION
```
$ wrench import_key
Usage: wrench [OPTIONS] COMMAND [ARGS]...
Try "wrench -h" for help.

Error: No such command "import_key".
```

```
$ wrench import-key -h                                                                2 ↵
Usage: wrench import-key [OPTIONS] PATH

  Import the given Passbolt private key.

Options:
  -h, --help  Show this message and exit.
```