### PR TITLE
added dump option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,11 @@ Add a resource::
   If you would like to share it, enter e-mail addresses below, separated by commas. Auto completion through Tab key is supported.
   Recipients:
 
+Dump all resources::
+
+  $ wrench dump > dump.json
+
+
 To see the list of all wrench commands, run `wrench` without any argument.
 
 Common issues

--- a/src/wrench/commands.py
+++ b/src/wrench/commands.py
@@ -21,6 +21,7 @@ import os
 import re
 import string
 import sys
+import json
 from enum import Enum
 from typing import Any, Callable, Dict, Iterable, List, Tuple, Union
 
@@ -276,6 +277,19 @@ def cli(ctx: Any, verbose: bool) -> None:
 
     if 'gpg' not in ctx.obj:
         ctx.obj['gpg'] = create_gpg(get_workdir())
+
+
+@cli.command()
+@click.pass_context
+def dump(ctx: Any) -> None:
+    """
+    Dump everything you have access to JSON
+    """
+
+    context = get_context(ctx.obj)
+    resources = get_resources(context.session)
+    json_dump = json.dumps([decrypt_resource(resource=resource, gpg=ctx.obj['gpg'], context=context)._asdict() for resource in resources])
+    print(json_dump)
 
 
 @cli.command()


### PR DESCRIPTION
Since there is no export option in the free Passbolt, here's a simple dump option to allow migration to an alternate password manager. I hope it's not too ugly