### PR TITLE
Workaround for decoding JSON data created by WebUI

### DIFF
--- a/src/wrench/resources.py
+++ b/src/wrench/resources.py
@@ -72,8 +72,21 @@ def decrypt_resource(resource: Resource, gpg: GPG, context: Context) -> Resource
     if resource.secret is not None:
         return resource
 
+    def is_json(myjson):
+      try:
+        json.loads(myjson)
+      except ValueError as e:
+        return False
+      return True
+
+    checkjson=utils.decrypt(data=get_resource_secret(session=context.session, resource_id=resource.id), gpg=gpg)
+    if is_json(checkjson):
+        validpassword=json.loads(checkjson)["password"]
+    else:
+        validpassword=checkjson
+
     return resource._replace(
-        secret=utils.decrypt(data=get_resource_secret(session=context.session, resource_id=resource.id), gpg=gpg)
+        secret=validpassword
     )
 
 

--- a/src/wrench/resources.py
+++ b/src/wrench/resources.py
@@ -28,6 +28,7 @@ from .services import add_resource as add_resource_service
 from .services import get_permissions, get_resource_secret
 from .services import share_resource as share_resource_service
 from .users import unfold_groups
+import json
 
 
 def resource_matches(resource: Resource, terms: str,


### PR DESCRIPTION
When creating an entry with the WebUI, the PGP message contains JSON instead of just the secret.